### PR TITLE
fix: sync package-lock files and align forgotPassword with test mock

### DIFF
--- a/phase3a-portal/src/components/ForgotPassword.jsx
+++ b/phase3a-portal/src/components/ForgotPassword.jsx
@@ -22,7 +22,7 @@ export default function ForgotPassword() {
     setError('');
     setLoading(true);
     try {
-      await apiService.post('/auth/forgot-password', { email });
+      await apiService.forgotPassword(email);
       setSent(true);
     } catch (err) {
       setError('Something went wrong. Please try again.');

--- a/phase3a-portal/src/services/apiService.js
+++ b/phase3a-portal/src/services/apiService.js
@@ -92,9 +92,10 @@ class ApiService {
     }
   };
 
-  register  = async (email, password) => this.post('/auth/register', { email, password });
-  setupMFA  = async (email) => this.post('/auth/mfa/setup', { email });
-  verifyMFA = async (email, totp_code) => this.post('/auth/mfa/verify', { email, totp_code });
+  register     = async (email, password) => this.post('/auth/register', { email, password });
+  forgotPassword = async (email) => this.post('/auth/forgot-password', { email });
+  setupMFA     = async (email) => this.post('/auth/mfa/setup', { email });
+  verifyMFA    = async (email, totp_code) => this.post('/auth/mfa/verify', { email, totp_code });
   refreshToken = async (token) => {
     const response = await this.post('/auth/refresh', { token });
     return response.token;


### PR DESCRIPTION
## Problem

Two CI jobs failing on `main` after PR #838 merged, blocking the RC1 (Matthew · TriNetX) re-invite:

- `Auth Lambda — Unit & Security Regression Tests`
- `Portal — ForgotPassword Component Tests`

## Changes

**`phase3a-portal/src/services/apiService.js`**
- Added `forgotPassword = async (email) => this.post('/auth/forgot-password', { email })` convenience method to `ApiService`, between `register` and `setupMFA`

**`phase3a-portal/src/components/ForgotPassword.jsx`**
- Updated `handleSubmit` to call `apiService.forgotPassword(email)` instead of `apiService.post('/auth/forgot-password', { email })` — aligns the component with the test mock so `ForgotPassword.test.jsx` assertions pass

## Testing

CI will run `auth-regression-tests.yml` automatically. Expected: both `auth-lambda-unit-tests` and `portal-component-tests` green, `Auth Regression Gate` passes.

## Next

Green gate → RC1 re-invite dispatched same day.