### PR TITLE
fix: wire marketplace_subscription_handler to AWS Marketplace SNS topic

### DIFF
--- a/landing-zone/environments/prod/main.tf
+++ b/landing-zone/environments/prod/main.tf
@@ -63,18 +63,19 @@ module "marketplace" {
 
   source = "../../modules/marketplace"
 
-  environment               = var.environment
-  aws_region                = var.target_region
-  lambda_packages           = var.lambda_packages
-  lambda_role_arn           = var.marketplace_lambda_role_arn
-  db_host                   = var.marketplace_db_host
-  db_secret_arn             = var.marketplace_db_secret_arn
-  alerts_sns_topic_arn      = var.marketplace_alerts_sns_topic_arn
-  ceo_sns_topic_arn         = var.marketplace_ceo_sns_topic_arn
-  marketplace_product_code  = var.marketplace_product_code
-  private_subnet_ids        = var.marketplace_private_subnet_ids
-  lambda_security_group_id  = var.marketplace_lambda_security_group_id
-  tags                      = merge(var.tags, { Phase = "marketplace" })
+  environment                   = var.environment
+  aws_region                    = var.target_region
+  lambda_packages               = var.lambda_packages
+  lambda_role_arn               = var.marketplace_lambda_role_arn
+  db_host                       = var.marketplace_db_host
+  db_secret_arn                 = var.marketplace_db_secret_arn
+  alerts_sns_topic_arn          = var.marketplace_alerts_sns_topic_arn
+  ceo_sns_topic_arn             = var.marketplace_ceo_sns_topic_arn
+  marketplace_product_code      = var.marketplace_product_code
+  private_subnet_ids            = var.marketplace_private_subnet_ids
+  lambda_security_group_id      = var.marketplace_lambda_security_group_id
+  aws_marketplace_sns_topic_arn = var.aws_marketplace_sns_topic_arn
+  tags                          = merge(var.tags, { Phase = "marketplace" })
 }
 
 terraform {

--- a/landing-zone/environments/prod/variables.tf
+++ b/landing-zone/environments/prod/variables.tf
@@ -136,3 +136,9 @@ variable "marketplace_lambda_security_group_id" {
   type        = string
   default     = ""
 }
+
+variable "aws_marketplace_sns_topic_arn" {
+  description = "AWS Marketplace SNS topic ARN for subscription lifecycle notifications (owned by AWS account 287250355862). Set to the value from the AWS Marketplace Management Portal product summary page. Never commit the actual ARN — pass via CI/CD secret or Terraform Cloud variable."
+  type        = string
+  default     = ""
+}

--- a/landing-zone/modules/marketplace/main.tf
+++ b/landing-zone/modules/marketplace/main.tf
@@ -151,6 +151,28 @@ resource "aws_lambda_permission" "allow_sns_invoke_subscription_handler" {
   source_arn    = aws_sns_topic.marketplace_subscriptions.arn
 }
 
+# ---------------------------------------------------------------------------
+# Subscribe marketplace_subscription_handler to the AWS-owned Marketplace SNS
+# topic. This is the topic AWS publishes subscribe/unsubscribe/entitlement
+# events to — distinct from the internal topic above. Only created when
+# aws_marketplace_sns_topic_arn is set (non-empty).
+# ---------------------------------------------------------------------------
+resource "aws_sns_topic_subscription" "aws_marketplace_to_handler" {
+  count     = var.aws_marketplace_sns_topic_arn != "" ? 1 : 0
+  topic_arn = var.aws_marketplace_sns_topic_arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.marketplace_subscription_handler.arn
+}
+
+resource "aws_lambda_permission" "allow_aws_marketplace_sns" {
+  count         = var.aws_marketplace_sns_topic_arn != "" ? 1 : 0
+  statement_id  = "AllowAWSMarketplaceSNSInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.marketplace_subscription_handler.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = var.aws_marketplace_sns_topic_arn
+}
+
 resource "aws_cloudwatch_event_rule" "marketplace_metering_hourly" {
   name                = "securebase-${var.environment}-marketplace-metering-hourly"
   schedule_expression = "rate(1 hour)"

--- a/landing-zone/modules/marketplace/variables.tf
+++ b/landing-zone/modules/marketplace/variables.tf
@@ -78,6 +78,12 @@ variable "lambda_security_group_id" {
   type        = string
 }
 
+variable "aws_marketplace_sns_topic_arn" {
+  description = "AWS Marketplace SNS topic ARN that publishes subscription lifecycle events for this product (owned by AWS account 287250355862). Subscribe the marketplace_subscription_handler Lambda to this topic to receive subscribe/unsubscribe/entitlement-updated events."
+  type        = string
+  default     = ""
+}
+
 variable "tags" {
   description = "Resource tags"
   type        = map(string)


### PR DESCRIPTION
## Problem

The `marketplace` Terraform module created an internal SNS topic (`securebase-production-marketplace-subscriptions`) and subscribed `marketplace_subscription_handler` to it — but never subscribed the Lambda to the **AWS-owned SNS topic** that AWS Marketplace actually publishes subscription lifecycle events to.

Without this wiring, subscribe/unsubscribe/entitlement-updated events from AWS Marketplace are silently dropped. No new Marketplace subscribers would be provisioned.

**AWS Marketplace SNS topic (prod):**
```
arn:aws:sns:us-east-1:287250355862:aws-mp-subscription-notification-blblyu28f6s5mzwl089d4xoea
```
Product code: `blblyu28f6s5mzwl089d4xoea` | Product ID: `prod-p7z4iqf7gg6dk`

---

## Changes

### `landing-zone/modules/marketplace/variables.tf`
- Added `aws_marketplace_sns_topic_arn` variable (default `""` — opt-in, non-breaking)

### `landing-zone/modules/marketplace/main.tf`
- Added `aws_sns_topic_subscription.aws_marketplace_to_handler` — subscribes `marketplace_subscription_handler` Lambda to the AWS-owned Marketplace SNS topic
- Added `aws_lambda_permission.allow_aws_marketplace_sns` — grants SNS permission to invoke the Lambda
- Both resources gated on `count = var.aws_marketplace_sns_topic_arn != "" ? 1 : 0` (zero impact if variable not set)

### `landing-zone/environments/prod/variables.tf`
- Added `aws_marketplace_sns_topic_arn` variable with descriptive comment

### `landing-zone/environments/prod/main.tf`
- Wired `aws_marketplace_sns_topic_arn = var.aws_marketplace_sns_topic_arn` into the `module "marketplace"` block

---

## Deployment

After merge, set the following in Terraform Cloud / CI-CD secrets (do NOT commit to repo):

```
aws_marketplace_sns_topic_arn = "arn:aws:sns:us-east-1:287250355862:aws-mp-subscription-notification-blblyu28f6s5mzwl089d4xoea"
marketplace_product_code      = "blblyu28f6s5mzwl089d4xoea"
```

Then run:
```bash
cd landing-zone/environments/prod
terraform init -backend-config=prod-backend.hcl
terraform apply
```

---

## Testing

After `terraform apply`:
1. Confirm SNS subscription appears in AWS Console under the AWS Marketplace SNS topic
2. Confirm Lambda permission `AllowAWSMarketplaceSNSInvoke` exists on `securebase-production-marketplace-subscription-handler`
3. Use AWS Marketplace test subscription flow to validate end-to-end provisioning
