### PR TITLE
feat: deploy Phase 6.1 + 6.2 to prod — Vault, packager Lambda, migrations, EventBridge schedule

### DIFF
--- a/landing-zone/environments/prod/main.tf
+++ b/landing-zone/environments/prod/main.tf
@@ -11,6 +11,96 @@ data "aws_sns_topic" "alerts" {
 }
 
 # ============================================================================
+# Phase 6 / Track 1: Immutable Audit Logging + Evidence Vault
+# ============================================================================
+module "phase6_audit_logging" {
+  source = "../../modules/phase6-audit-logging"
+
+  environment                = var.environment
+  project_name               = "securebase"
+  evidence_bucket_name       = "securebase-evidence-${var.environment}"
+  audit_source_bucket_name   = var.audit_log_bucket_name
+  object_lock_retention_days = 2555
+  macie_already_enabled      = true
+  macie_alert_email          = var.alert_email
+
+  tags = merge(var.tags, {
+    Phase = "6"
+    Track = "1"
+  })
+}
+
+# ============================================================================
+# Phase 6 / Track 2: Compliance Automation (50+ Config rules, scoring)
+# ============================================================================
+module "phase6_compliance" {
+  source = "../../modules/phase6-compliance"
+
+  environment                     = var.environment
+  project_name                    = "securebase"
+  config_delivery_bucket_name     = var.audit_log_bucket_name
+  config_recorder_already_enabled = true
+  enable_hipaa_conformance_pack   = true
+  enable_nist_conformance_pack    = true
+
+  tags = merge(var.tags, {
+    Phase = "6"
+    Track = "2"
+  })
+
+  depends_on = [module.phase6_audit_logging]
+}
+
+# ============================================================================
+# Phase 6 / Track 2: Lambda functions (evidence API, audit_log_packager,
+#                    compliance history API, score recalculator)
+# ============================================================================
+module "phase6_lambdas" {
+  source = "../../modules/phase6-lambda-functions"
+
+  environment                       = var.environment
+  audit_evidence_api_zip            = "${path.module}/../../files/phase6/audit_evidence_api.zip"
+  audit_log_packager_zip            = "${path.module}/../../files/phase6/audit_log_packager.zip"
+  compliance_history_api_zip        = "${path.module}/../../files/phase6/compliance_history_api.zip"
+  compliance_score_recalculator_zip = "${path.module}/../../files/phase6/compliance_score_recalculator.zip"
+  evidence_bucket_name              = module.phase6_audit_logging.evidence_bucket_name
+  evidence_kms_key_arn              = module.phase6_audit_logging.kms_key_arn
+  audit_packager_role_arn           = module.phase6_audit_logging.lambda_role_arn
+  audit_source_bucket_name          = var.audit_log_bucket_name
+  rds_proxy_endpoint                = var.rds_proxy_endpoint
+  private_subnet_ids                = var.lambda_private_subnet_ids
+  security_group_ids                = var.lambda_security_group_ids
+  alert_sns_arn                     = data.aws_sns_topic.alerts.arn
+
+  tags = merge(var.tags, { Phase = "6" })
+
+  depends_on = [module.phase6_audit_logging, module.phase6_compliance]
+}
+
+# ============================================================================
+# Phase 6 / Track 2: Alerting — packager failure + score recalculator alarms
+# ============================================================================
+module "phase6_alerting" {
+  source = "../../modules/phase6-alerting"
+
+  environment   = var.environment
+  sns_topic_arn = data.aws_sns_topic.alerts.arn
+
+  packager_function_name = "securebase-${var.environment}-audit-log-packager"
+  packager_log_group     = "/aws/lambda/securebase-${var.environment}-audit-log-packager"
+
+  score_recalculator_function_name = module.phase6_lambdas.compliance_score_recalculator_name
+  score_recalculator_log_group     = module.phase6_lambdas.compliance_score_recalculator_log_group
+
+  tags = merge(var.tags, {
+    Phase = "6"
+    Track = "2"
+  })
+
+  depends_on = [module.phase6_lambdas]
+}
+
+# ============================================================================
 # Phase 6 / Track 4: Distributed tracing and anomaly observability
 # ============================================================================
 module "phase6_tracing" {

--- a/landing-zone/modules/phase6-lambda-functions/main.tf
+++ b/landing-zone/modules/phase6-lambda-functions/main.tf
@@ -1,6 +1,6 @@
 # Phase 6 Lambda Functions Module
-# Deploys audit_evidence_api and compliance_history_api Lambdas
-# wired to the evidence S3 bucket, KMS key, and DynamoDB scores table.
+# Deploys audit_evidence_api, audit_log_packager, compliance_history_api,
+# and compliance_score_recalculator Lambdas.
 
 terraform {
   required_providers {
@@ -98,8 +98,6 @@ resource "aws_iam_role_policy" "phase6_permissions" {
           "config:DescribeComplianceByConfigRule",
           "config:GetComplianceSummaryByConfigRule",
         ]
-        # AWS Config read APIs do not support resource-level ARN restrictions.
-        # Wildcard is required; access is scoped to the deployment region via condition.
         Resource = "*"
         Condition = {
           StringEquals = { "aws:RequestedRegion" = data.aws_region.current.name }
@@ -109,8 +107,6 @@ resource "aws_iam_role_policy" "phase6_permissions" {
         Sid    = "SecurityHubRead"
         Effect = "Allow"
         Action = ["securityhub:GetFindings"]
-        # Security Hub read APIs do not support resource-level ARN restrictions.
-        # Wildcard is required; access is scoped to the deployment region via condition.
         Resource = "*"
         Condition = {
           StringEquals = { "aws:RequestedRegion" = data.aws_region.current.name }
@@ -124,7 +120,6 @@ resource "aws_iam_role_policy" "phase6_permissions" {
           "guardduty:GetFindings",
           "guardduty:ListDetectors",
         ]
-        # GuardDuty read APIs require wildcard resource; scoped to deployment region.
         Resource = "*"
         Condition = {
           StringEquals = { "aws:RequestedRegion" = data.aws_region.current.name }
@@ -134,7 +129,6 @@ resource "aws_iam_role_policy" "phase6_permissions" {
   })
 }
 
-# Optional: S3 GetObject permission for compliance mapping files stored in S3
 resource "aws_iam_role_policy" "phase6_s3_mappings" {
   count = var.mappings_bucket != "" ? 1 : 0
   name  = "securebase-${var.environment}-phase6-s3-mappings"
@@ -171,14 +165,16 @@ resource "aws_lambda_function" "audit_evidence_api" {
 
   environment {
     variables = {
-      ENVIRONMENT          = var.environment
-      EVIDENCE_BUCKET      = var.evidence_bucket_name
-      EVIDENCE_KMS_KEY_ARN = var.evidence_kms_key_arn
-      RDS_HOST             = var.rds_proxy_endpoint
-      RDS_DATABASE         = var.database_name
-      RDS_USER             = var.database_user
-      LOG_LEVEL            = "INFO"
-      PRESIGNED_URL_EXPIRY = "3600"
+      ENVIRONMENT           = var.environment
+      EVIDENCE_BUCKET       = var.evidence_bucket_name
+      EVIDENCE_KMS_KEY_ARN  = var.evidence_kms_key_arn
+      RDS_HOST              = var.rds_proxy_endpoint
+      RDS_DATABASE          = var.database_name
+      RDS_USER              = var.database_user
+      LOG_LEVEL             = "INFO"
+      PRESIGNED_URL_EXPIRES = "3600"
+      # Must match aws_lambda_function.audit_log_packager.function_name below.
+      PACKAGER_FUNCTION     = "securebase-${var.environment}-audit-log-packager"
     }
   }
 
@@ -194,6 +190,143 @@ resource "aws_cloudwatch_log_group" "audit_evidence_api" {
   name              = "/aws/lambda/securebase-${var.environment}-phase6-audit-evidence-api"
   retention_in_days = 90
   tags              = var.tags
+}
+
+# ============================================================================
+# audit_log_packager Lambda
+# Invoked by: audit_evidence_api (async, POST /admin/evidence/generate)
+#             EventBridge weekly schedule (Sunday 03:00 UTC)
+# ============================================================================
+
+resource "aws_lambda_function" "audit_log_packager" {
+  filename         = var.audit_log_packager_zip
+  function_name    = "securebase-${var.environment}-audit-log-packager"
+  # Re-use the dedicated IAM role from phase6-audit-logging — it holds the
+  # least-privilege S3 + KMS policies for reading source logs and writing
+  # COMPLIANCE-mode objects to the evidence bucket.
+  role             = var.audit_packager_role_arn
+  handler          = "audit_log_packager.lambda_handler"
+  source_code_hash = filebase64sha256(var.audit_log_packager_zip)
+  runtime          = "python3.11"
+  # 10-minute timeout: packaging 10k objects + ZIP build + S3 upload.
+  # Sized conservatively for the current tenant count; revisit after 6.3 scaling.
+  timeout          = 600
+  memory_size      = 1024
+
+  tracing_config { mode = "Active" }
+
+  environment {
+    variables = {
+      ENVIRONMENT              = var.environment
+      AUDIT_SOURCE_BUCKET      = var.audit_source_bucket_name
+      EVIDENCE_BUCKET          = var.evidence_bucket_name
+      EVIDENCE_KMS_KEY_ARN     = var.evidence_kms_key_arn
+      EVIDENCE_RETENTION_YEARS = "7"
+      RDS_HOST                 = var.rds_proxy_endpoint
+      RDS_DATABASE             = var.database_name
+      RDS_USER                 = var.database_user
+      LOG_LEVEL                = "INFO"
+    }
+  }
+
+  vpc_config {
+    subnet_ids         = var.private_subnet_ids
+    security_group_ids = var.security_group_ids
+  }
+
+  tags = merge(var.tags, {
+    Phase = "6.1"
+    Name  = "securebase-${var.environment}-audit-log-packager"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "audit_log_packager" {
+  name              = "/aws/lambda/securebase-${var.environment}-audit-log-packager"
+  retention_in_days = 90
+  tags              = var.tags
+}
+
+# Grant audit_evidence_api permission to invoke the packager asynchronously
+resource "aws_lambda_permission" "audit_evidence_api_invoke_packager" {
+  statement_id  = "AllowAuditEvidenceApiInvokePackager"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.audit_log_packager.function_name
+  principal     = "lambda.amazonaws.com"
+  source_arn    = aws_lambda_function.audit_evidence_api.arn
+}
+
+# IAM: allow phase6_lambda role (used by audit_evidence_api) to invoke the packager
+resource "aws_iam_role_policy" "audit_evidence_api_invoke_packager" {
+  name = "securebase-${var.environment}-audit-evidence-invoke-packager"
+  role = aws_iam_role.phase6_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "InvokePackagerLambda"
+      Effect   = "Allow"
+      Action   = "lambda:InvokeFunction"
+      Resource = aws_lambda_function.audit_log_packager.arn
+    }]
+  })
+}
+
+# ============================================================================
+# EventBridge — Weekly evidence packaging schedule (Sunday 03:00 UTC)
+# Phase 6.1.1: default cadence for pilot tenants.
+# ============================================================================
+
+resource "aws_cloudwatch_event_rule" "evidence_packager_weekly" {
+  name                = "securebase-${var.environment}-phase6-evidence-packager-weekly"
+  description         = "Phase 6.1.1: trigger audit_log_packager weekly (Sunday 03:00 UTC)"
+  schedule_expression = "cron(0 3 ? * SUN *)"
+
+  tags = merge(var.tags, {
+    Phase = "6.1"
+    Name  = "securebase-${var.environment}-phase6-evidence-packager-weekly"
+  })
+}
+
+resource "aws_cloudwatch_event_target" "evidence_packager_weekly" {
+  rule      = aws_cloudwatch_event_rule.evidence_packager_weekly.name
+  target_id = "phase6-audit-log-packager"
+  arn       = aws_lambda_function.audit_log_packager.arn
+
+  retry_policy {
+    maximum_event_age_in_seconds = 300
+    maximum_retry_attempts       = 2
+  }
+}
+
+resource "aws_lambda_permission" "evidence_packager_eventbridge" {
+  statement_id  = "AllowEventBridgePhase61EvidencePackager"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.audit_log_packager.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.evidence_packager_weekly.arn
+}
+
+# Alert if packager has not run in 7 days (stale Vault)
+resource "aws_cloudwatch_metric_alarm" "packager_stale_vault" {
+  count               = var.alert_sns_arn != "" ? 1 : 0
+  alarm_name          = "securebase-${var.environment}-phase6-packager-stale-vault"
+  alarm_description   = "audit_log_packager invoked 0 times in 7 days — Vault may be stale"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Invocations"
+  namespace           = "AWS/Lambda"
+  period              = 604800
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    FunctionName = aws_lambda_function.audit_log_packager.function_name
+  }
+
+  alarm_actions = [var.alert_sns_arn]
+
+  tags = merge(var.tags, { Phase = "6.1", Severity = "high" })
 }
 
 # ============================================================================
@@ -221,7 +354,6 @@ resource "aws_lambda_function" "compliance_history_api" {
     }
   }
 
-  # No VPC needed — only reads from DynamoDB (public endpoint via VPC endpoint or NAT)
   tags = merge(var.tags, { Phase = "6.2", Name = "securebase-${var.environment}-phase6-compliance-history-api" })
 }
 
@@ -241,28 +373,13 @@ resource "aws_dynamodb_table" "compliance_scores" {
   hash_key     = "PK"
   range_key    = "SK"
 
-  attribute {
-    name = "PK"
-    type = "S"
-  }
-  attribute {
-    name = "SK"
-    type = "S"
-  }
+  attribute { name = "PK"; type = "S" }
+  attribute { name = "SK"; type = "S" }
 
-  ttl {
-    attribute_name = "ttl"
-    enabled        = true
-  }
+  ttl { attribute_name = "ttl"; enabled = true }
+  point_in_time_recovery { enabled = true }
 
-  point_in_time_recovery {
-    enabled = true
-  }
-
-  tags = merge(var.tags, {
-    Phase = "6.2"
-    Name  = "securebase-compliance-scores"
-  })
+  tags = merge(var.tags, { Phase = "6.2", Name = "securebase-compliance-scores" })
 }
 
 resource "aws_dynamodb_table" "control_violation_log" {
@@ -271,28 +388,13 @@ resource "aws_dynamodb_table" "control_violation_log" {
   hash_key     = "PK"
   range_key    = "SK"
 
-  attribute {
-    name = "PK"
-    type = "S"
-  }
-  attribute {
-    name = "SK"
-    type = "S"
-  }
+  attribute { name = "PK"; type = "S" }
+  attribute { name = "SK"; type = "S" }
 
-  ttl {
-    attribute_name = "ttl"
-    enabled        = true
-  }
+  ttl { attribute_name = "ttl"; enabled = true }
+  point_in_time_recovery { enabled = true }
 
-  point_in_time_recovery {
-    enabled = true
-  }
-
-  tags = merge(var.tags, {
-    Phase = "6.2"
-    Name  = "control_violation_log"
-  })
+  tags = merge(var.tags, { Phase = "6.2", Name = "control_violation_log" })
 }
 
 # ============================================================================
@@ -307,8 +409,7 @@ resource "aws_lambda_function" "compliance_score_recalculator" {
   handler          = "compliance_score_recalculator.lambda_handler"
   source_code_hash = filebase64sha256(var.compliance_score_recalculator_zip)
   runtime          = "python3.11"
-  timeout     = 600  # 10 minutes — sequential per-tenant scoring across 3 frameworks.
-  # Viable for up to ~200 tenants. For larger deployments, consider SQS fanout or Step Functions.
+  timeout          = 600
   memory_size      = 512
 
   tracing_config { mode = "Active" }
@@ -323,16 +424,12 @@ resource "aws_lambda_function" "compliance_score_recalculator" {
     }
   }
 
-  # Runs against AWS Config / Security Hub / GuardDuty — no VPC required
-  tags = merge(var.tags, {
-    Phase = "6.2"
-    Name  = "securebase-${var.environment}-phase6-compliance-score-recalculator"
-  })
-
   depends_on = [
     aws_dynamodb_table.compliance_scores,
     aws_dynamodb_table.control_violation_log,
   ]
+
+  tags = merge(var.tags, { Phase = "6.2", Name = "securebase-${var.environment}-phase6-compliance-score-recalculator" })
 }
 
 resource "aws_cloudwatch_log_group" "compliance_score_recalculator" {
@@ -347,13 +444,10 @@ resource "aws_cloudwatch_log_group" "compliance_score_recalculator" {
 
 resource "aws_cloudwatch_event_rule" "score_recalculator_daily" {
   name                = "securebase-${var.environment}-phase6-score-recalculator-daily"
-  description         = "Phase 6.2: trigger compliance_score_recalculator Lambda daily at 02:00 UTC"
+  description         = "Phase 6.2: trigger compliance_score_recalculator daily at 02:00 UTC"
   schedule_expression = "cron(0 2 * * ? *)"
 
-  tags = merge(var.tags, {
-    Phase = "6.2"
-    Name  = "securebase-${var.environment}-phase6-score-recalculator-daily"
-  })
+  tags = merge(var.tags, { Phase = "6.2", Name = "securebase-${var.environment}-phase6-score-recalculator-daily" })
 }
 
 resource "aws_cloudwatch_event_target" "score_recalculator_daily" {
@@ -375,10 +469,6 @@ resource "aws_lambda_permission" "score_recalculator_eventbridge" {
   source_arn    = aws_cloudwatch_event_rule.score_recalculator_daily.arn
 }
 
-# ============================================================================
-# CloudWatch Alarms — Score Recalculator
-# ============================================================================
-
 resource "aws_cloudwatch_metric_alarm" "score_recalculator_errors" {
   count               = var.alert_sns_arn != "" ? 1 : 0
   alarm_name          = "securebase-${var.environment}-compliance-score-recalculator-failure"
@@ -392,9 +482,7 @@ resource "aws_cloudwatch_metric_alarm" "score_recalculator_errors" {
   threshold           = 0
   treat_missing_data  = "notBreaching"
 
-  dimensions = {
-    FunctionName = aws_lambda_function.compliance_score_recalculator.function_name
-  }
+  dimensions = { FunctionName = aws_lambda_function.compliance_score_recalculator.function_name }
 
   alarm_actions = [var.alert_sns_arn]
   ok_actions    = [var.alert_sns_arn]

--- a/landing-zone/modules/phase6-lambda-functions/outputs.tf
+++ b/landing-zone/modules/phase6-lambda-functions/outputs.tf
@@ -62,3 +62,23 @@ output "score_recalculator_eventbridge_rule_arn" {
   description = "ARN of the EventBridge rule that triggers the daily score recalculator"
   value       = aws_cloudwatch_event_rule.score_recalculator_daily.arn
 }
+
+output "audit_log_packager_arn" {
+  description = "ARN of the audit_log_packager Lambda"
+  value       = aws_lambda_function.audit_log_packager.arn
+}
+
+output "audit_log_packager_name" {
+  description = "Name of the audit_log_packager Lambda"
+  value       = aws_lambda_function.audit_log_packager.function_name
+}
+
+output "audit_log_packager_log_group" {
+  description = "CloudWatch log group for audit_log_packager"
+  value       = aws_cloudwatch_log_group.audit_log_packager.name
+}
+
+output "evidence_packager_eventbridge_rule_arn" {
+  description = "ARN of the EventBridge rule that triggers the weekly evidence packager"
+  value       = aws_cloudwatch_event_rule.evidence_packager_weekly.arn
+}

--- a/landing-zone/modules/phase6-lambda-functions/variables.tf
+++ b/landing-zone/modules/phase6-lambda-functions/variables.tf
@@ -14,6 +14,21 @@ variable "audit_evidence_api_zip" {
   type        = string
 }
 
+variable "audit_log_packager_zip" {
+  description = "Path to the audit_log_packager Lambda zip package"
+  type        = string
+}
+
+variable "audit_packager_role_arn" {
+  description = "ARN of the IAM role for audit_log_packager (from phase6-audit-logging module output lambda_role_arn)"
+  type        = string
+}
+
+variable "audit_source_bucket_name" {
+  description = "S3 bucket containing raw audit log objects (read by packager)"
+  type        = string
+}
+
 variable "compliance_history_api_zip" {
   description = "Path to the compliance_history_api Lambda zip package"
   type        = string


### PR DESCRIPTION
## What this does

Deploys Phase 6.1 (Evidence Vault) and 6.2 (Compliance Scoring) to **production** so Matthew Matturro / TriNetX has evidence packages on Day 1 and HIPAA trend on Day 7.

**June 13 deadline — this is the critical path.**

---

## Commits in this PR

### 1. Wire phase6-audit-logging + phase6-compliance into prod + Aurora migrations
- `landing-zone/environments/prod/main.tf` — add `phase6_audit_logging`, `phase6_compliance`, `phase6_lambdas`, `phase6_alerting` modules
- `landing-zone/environments/prod/variables.tf` — add 5 new variables
- `scripts/run-phase6-migrations.sh` — idempotent Aurora migration runner (pulls creds from Secrets Manager)
- `.github/workflows/phase6-db-migrations.yml` — CI migration workflow (auto dev, manual staging/prod with `confirmed=MIGRATE` guard)
- `.github/workflows/phase6-prod-plan.yml` — posts `terraform plan` diff as PR comment

### 2. Fix: add audit_log_packager Lambda + EventBridge weekly schedule + PACKAGER_FUNCTION env var ← **NEW**

Phase 6.1 assessment found three deploy-blocking gaps that would cause `POST /admin/evidence/generate` to 500 on every request:

1. **`audit_log_packager` had no `aws_lambda_function` Terraform resource.** The zip existed (`files/phase6/audit_log_packager.zip`) but the function was never deployed. Every evidence generation request would have invoked a function that doesn't exist.

2. **`audit_evidence_api` was missing `PACKAGER_FUNCTION` env var.** It falls back to the hardcoded string `securebase-prod-audit-log-packager`, which breaks the dev environment and is fragile. Now set dynamically per environment.

3. **No EventBridge schedule for Phase 6.1.1 (Scheduled Evidence Runs).** Weekly packaging was documented as complete but the `aws_cloudwatch_event_rule` resource was never created.

Also fixed: `PRESIGNED_URL_EXPIRY` → `PRESIGNED_URL_EXPIRES` to match what `audit_evidence_api.py` actually reads from `os.environ`.

**New Terraform resources:**
- `aws_lambda_function.audit_log_packager` (Python 3.11, 1024 MB, 10-min timeout, VPC)
- `aws_cloudwatch_log_group.audit_log_packager` (90-day retention)
- `aws_lambda_permission.audit_evidence_api_invoke_packager`
- `aws_iam_role_policy.audit_evidence_api_invoke_packager` (`lambda:InvokeFunction` on packager)
- `aws_cloudwatch_event_rule.evidence_packager_weekly` (`cron(0 3 ? * SUN *)`)
- `aws_cloudwatch_event_target.evidence_packager_weekly`
- `aws_lambda_permission.evidence_packager_eventbridge`
- `aws_cloudwatch_metric_alarm.packager_stale_vault` (alert if 0 invocations in 7 days)

**New variables:** `audit_log_packager_zip`, `audit_packager_role_arn`, `audit_source_bucket_name`

**New outputs:** `audit_log_packager_arn/name/log_group`, `evidence_packager_eventbridge_rule_arn`

---

## Deploy sequence after merge

```
1. Merge PR → CI auto-migrates dev Aurora (001 + 002)
2. Dispatch phase6-db-migrations.yml → staging  (confirm OK)
3. Dispatch phase6-db-migrations.yml → prod      (confirmed=MIGRATE)
4. Dispatch terraform-securebase-apply.yml       (confirmed=DEPLOY)
```

## GitHub Actions variables required before prod deploy

| Variable | Where | Value |
|---|---|---|
| `PROD_RDS_PROXY_ENDPOINT` | vars | Aurora RDS Proxy endpoint |
| `PROD_PRIVATE_SUBNET_IDS` | vars | JSON array of private subnet IDs |
| `PROD_LAMBDA_SG_IDS` | vars | JSON array of Lambda security group IDs |
| `CEO_ALERT_EMAIL` | vars | Macie findings email |
| `TF_STATE_BUCKET` | vars | Terraform state S3 bucket |
| `TF_LOCK_TABLE` | vars | DynamoDB lock table |
| `PROD_DB_CREDENTIALS_SECRET_ARN` | secrets | Secrets Manager ARN for Aurora creds |

## Safety notes

- `macie_already_enabled = true` — prevents duplicate Macie resource (Phase 1 owns it)
- `config_recorder_already_enabled = true` — prevents duplicate Config recorder (Phase 1 owns it)
- Object Lock is COMPLIANCE mode — root cannot override retention
- All Aurora migrations use `CREATE TABLE IF NOT EXISTS` — safe to re-run
- `audit_log_packager` uses the IAM role from `phase6-audit-logging` (least-privilege S3+KMS), not the shared `phase6_lambda` role