### PR TITLE
fix: run Phase 6 migrations via VPC-resident db_migrator Lambda

### DIFF
--- a/.github/workflows/phase6-db-migrations.yml
+++ b/.github/workflows/phase6-db-migrations.yml
@@ -1,0 +1,97 @@
+name: Phase 6 - DB migrations
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        default: dev
+        options: [dev, staging, prod]
+      confirmed:
+        description: "Required for prod only: type MIGRATE"
+        required: false
+        type: string
+      validate_tables:
+        description: "Run post-migration table validation"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment == 'prod' && 'production' || '' }}
+    steps:
+      - name: Validate prod confirmation token
+        if: github.event.inputs.environment == 'prod'
+        run: |
+          if [ "${{ github.event.inputs.confirmed }}" != "MIGRATE" ]; then
+            echo "::error::Production migration aborted: set confirmed=MIGRATE to continue."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ github.event.inputs.environment == 'prod' && secrets.AWS_ROLE_ARN_PROD || secrets.AWS_ROLE_ARN }}
+          role-session-name: phase6-migration-${{ github.event.inputs.environment }}
+          aws-region: us-east-1
+          mask-aws-account-id: true
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Resolve Lambda name and secret ARN
+        id: config
+        run: |
+          ENV="${{ github.event.inputs.environment }}"
+          echo "function_name=securebase-${ENV}-db-migrator" >> "$GITHUB_OUTPUT"
+          if [ "$ENV" = "prod" ]; then
+            echo "secret_arn=${{ secrets.PROD_DB_CREDENTIALS_SECRET_ARN }}" >> "$GITHUB_OUTPUT"
+          elif [ "$ENV" = "staging" ]; then
+            echo "secret_arn=${{ secrets.STAGING_DB_CREDENTIALS_SECRET_ARN }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "secret_arn=${{ secrets.DEV_DB_CREDENTIALS_SECRET_ARN }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build migration payload
+        run: |
+          VALIDATE="${{ github.event.inputs.validate_tables }}"
+          cat > /tmp/payload.json <<EOF
+          {
+            "db_secret_arn": "${{ steps.config.outputs.secret_arn }}",
+            "migration_files": ["001_audit_evidence_tables", "002_compliance_score_history"],
+            "validate_required_tables": ${VALIDATE:-false}
+          }
+          EOF
+
+      - name: Invoke db-migrator Lambda
+        run: |
+          aws lambda invoke \
+            --function-name "${{ steps.config.outputs.function_name }}" \
+            --payload file:///tmp/payload.json \
+            --cli-binary-format raw-in-base64-out \
+            --log-type Tail \
+            --query 'LogResult' \
+            --output text \
+            /tmp/lambda-response.json \
+            | base64 --decode || true
+          echo "--- Lambda response ---"
+          cat /tmp/lambda-response.json
+
+      - name: Assert migration succeeded
+        run: |
+          STATUS=$(jq -r '.statusCode' /tmp/lambda-response.json)
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Migration failed — statusCode=${STATUS}"
+            jq '.' /tmp/lambda-response.json
+            exit 1
+          fi
+          echo "Migration succeeded:"
+          jq '.results[]' /tmp/lambda-response.json

--- a/landing-zone/modules/db-migrator/main.tf
+++ b/landing-zone/modules/db-migrator/main.tf
@@ -1,0 +1,67 @@
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+  }
+}
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "migrator" {
+  name = "securebase-${var.environment}-db-migrator"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{ Action = "sts:AssumeRole", Effect = "Allow", Principal = { Service = "lambda.amazonaws.com" } }]
+  })
+  tags = var.tags
+}
+resource "aws_iam_role_policy_attachment" "vpc_execution" {
+  role       = aws_iam_role.migrator.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+resource "aws_iam_role_policy" "secrets" {
+  name = "securebase-${var.environment}-db-migrator-secrets"
+  role = aws_iam_role.migrator.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{ Sid = "ReadDBSecrets", Effect = "Allow", Action = ["secretsmanager:GetSecretValue"], Resource = var.allowed_secret_arns }]
+  })
+}
+resource "aws_lambda_permission" "github_actions" {
+  for_each      = toset(var.invoker_role_arns)
+  statement_id  = "AllowGitHubActions-${replace(each.key, "/[^a-zA-Z0-9]/", "-")}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.migrator.function_name
+  principal     = "sts.amazonaws.com"
+  source_arn    = each.key
+}
+resource "aws_security_group" "migrator" {
+  name        = "securebase-${var.environment}-db-migrator"
+  description = "db-migrator Lambda egress to RDS proxy and Secrets Manager only"
+  vpc_id      = var.vpc_id
+  egress { description = "PostgreSQL to RDS proxy", from_port = 5432, to_port = 5432, protocol = "tcp", cidr_blocks = ["0.0.0.0/0"] }
+  egress { description = "HTTPS for Secrets Manager", from_port = 443, to_port = 443, protocol = "tcp", cidr_blocks = ["0.0.0.0/0"] }
+  tags = merge(var.tags, { Name = "securebase-${var.environment}-db-migrator" })
+}
+resource "aws_cloudwatch_log_group" "migrator" {
+  name              = "/aws/lambda/securebase-${var.environment}-db-migrator"
+  retention_in_days = 90
+  tags              = var.tags
+}
+resource "aws_lambda_function" "migrator" {
+  function_name    = "securebase-${var.environment}-db-migrator"
+  description      = "VPC-resident migration runner for Phase 6 Aurora schema"
+  role             = aws_iam_role.migrator.arn
+  filename         = var.zip_path
+  runtime          = "python3.12"
+  handler          = "db_migrator.handler"
+  timeout          = 300
+  memory_size      = 256
+  source_code_hash = filebase64sha256(var.zip_path)
+  vpc_config {
+    subnet_ids         = var.private_subnet_ids
+    security_group_ids = [aws_security_group.migrator.id]
+  }
+  environment { variables = { AWS_REGION_OVERRIDE = data.aws_region.current.name } }
+  depends_on = [aws_iam_role_policy_attachment.vpc_execution, aws_cloudwatch_log_group.migrator]
+  tags = var.tags
+}

--- a/landing-zone/modules/db-migrator/outputs.tf
+++ b/landing-zone/modules/db-migrator/outputs.tf
@@ -1,0 +1,3 @@
+output "function_name" { value = aws_lambda_function.migrator.function_name }
+output "function_arn"  { value = aws_lambda_function.migrator.arn }
+output "role_arn"      { value = aws_iam_role.migrator.arn }

--- a/landing-zone/modules/db-migrator/variables.tf
+++ b/landing-zone/modules/db-migrator/variables.tf
@@ -1,0 +1,7 @@
+variable "environment" { type = string }
+variable "vpc_id" { type = string }
+variable "private_subnet_ids" { type = list(string) }
+variable "zip_path" { type = string, default = "../../../files/phase6/db_migrator.zip" }
+variable "allowed_secret_arns" { type = list(string) }
+variable "invoker_role_arns" { type = list(string), default = [] }
+variable "tags" { type = map(string), default = {} }

--- a/phase6-backend/functions/db_migrator.py
+++ b/phase6-backend/functions/db_migrator.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+import json, logging, os
+from typing import Any
+import boto3, psycopg2
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+DEFAULT_MIGRATIONS = ["001_audit_evidence_tables", "002_compliance_score_history"]
+REQUIRED_TABLES = ["schema_migrations", "evidence_packages", "macie_findings", "compliance_score_daily", "control_violation_log"]
+MIGRATION_SQL: dict[str, str] = {}
+
+def _load_inline_sql() -> None:
+    import pathlib
+    base = pathlib.Path("/var/task/migrations")
+    if not base.exists():
+        return
+    for f in sorted(base.glob("*.sql")):
+        MIGRATION_SQL[f.stem] = f.read_text()
+
+_load_inline_sql()
+
+def _get_conn(secret_arn: str):
+    sm = boto3.client("secretsmanager", region_name=REGION)
+    secret = json.loads(sm.get_secret_value(SecretId=secret_arn)["SecretString"])
+    host = secret.get("host") or secret.get("hostname")
+    port = int(secret.get("port", 5432))
+    dbname = secret.get("dbname") or secret.get("database", "securebase")
+    user = secret.get("username") or secret.get("user")
+    password = secret.get("password")
+    if not all([host, user, password]):
+        raise ValueError(f"Incomplete credentials in secret {secret_arn}")
+    return psycopg2.connect(host=host, port=port, dbname=dbname, user=user, password=password, sslmode="require", connect_timeout=10)
+
+def _bootstrap(cur: Any) -> None:
+    cur.execute("CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY, applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW());")
+
+def _apply(cur: Any, version: str, sql: str) -> str:
+    cur.execute("SELECT 1 FROM schema_migrations WHERE version = %s LIMIT 1;", (version,))
+    if cur.fetchone():
+        return "skipped"
+    logger.info("[apply] %s", version)
+    cur.execute(sql)
+    cur.execute("INSERT INTO schema_migrations(version) VALUES (%s) ON CONFLICT (version) DO NOTHING;", (version,))
+    return "applied"
+
+def _validate(cur: Any) -> list[str]:
+    missing = []
+    for table in REQUIRED_TABLES:
+        cur.execute("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name=%s);", (table,))
+        if not cur.fetchone()[0]:
+            missing.append(table)
+    return missing
+
+def handler(event: dict, _context: Any) -> dict:
+    secret_arn: str = event.get("db_secret_arn", "")
+    if not secret_arn:
+        return {"statusCode": 400, "error": "db_secret_arn is required"}
+    migration_names: list[str] = event.get("migration_files", DEFAULT_MIGRATIONS)
+    validate: bool = bool(event.get("validate_required_tables", False))
+    results: list[dict] = []
+    missing_tables: list[str] = []
+    try:
+        conn = _get_conn(secret_arn)
+        conn.autocommit = False
+        with conn:
+            with conn.cursor() as cur:
+                _bootstrap(cur)
+                for version in migration_names:
+                    sql = MIGRATION_SQL.get(version)
+                    if sql is None:
+                        results.append({"version": version, "status": "error", "detail": "SQL not found in Lambda bundle"})
+                        conn.rollback()
+                        return {"statusCode": 500, "error": f"SQL not bundled for migration: {version}", "results": results}
+                    status = _apply(cur, version, sql)
+                    results.append({"version": version, "status": status})
+                if validate:
+                    missing_tables = _validate(cur)
+        conn.close()
+    except Exception as exc:
+        logger.exception("Migration failed")
+        return {"statusCode": 500, "error": str(exc), "results": results}
+    if missing_tables:
+        return {"statusCode": 500, "error": "Validation failed — missing required tables", "missing_tables": missing_tables, "results": results}
+    return {"statusCode": 200, "results": results, "validated": validate}

--- a/scripts/build-db-migrator-zip.sh
+++ b/scripts/build-db-migrator-zip.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+OUT="files/phase6/db_migrator.zip"
+TMP=$(mktemp -d)
+cp phase6-backend/functions/db_migrator.py "$TMP/db_migrator.py"
+pip install psycopg2-binary --target "$TMP" --quiet --no-cache-dir
+mkdir -p "$TMP/migrations"
+for f in phase6-backend/database/migrations/*.sql; do cp "$f" "$TMP/migrations/"; done
+mkdir -p files/phase6
+(cd "$TMP" && zip -r - .) > "$OUT"
+rm -rf "$TMP"
+echo "[build] done: $OUT ($(du -sh $OUT | cut -f1))"


### PR DESCRIPTION
## Root cause

GitHub-hosted runners have no network path to Aurora — it lives in a private VPC. Every `psql` call in `run-phase6-migrations.sh` timed out, which is why dev (×2), staging, and prod all failed identically today.

## What changed

Replaces direct `psql` with a VPC-resident `db_migrator` Lambda. The workflow now calls `aws lambda invoke` over HTTPS — works from any runner. The Lambda runs inside the private subnet, fetches credentials from Secrets Manager, applies idempotent migrations, and returns structured JSON.

### Files
| File | Change |
|------|--------|
| `phase6-backend/functions/db_migrator.py` | New Lambda handler (Python 3.12, psycopg2) |
| `landing-zone/modules/db-migrator/main.tf` | Terraform: IAM role, VPC security group, Lambda, log group |
| `landing-zone/modules/db-migrator/variables.tf` | Module variables |
| `landing-zone/modules/db-migrator/outputs.tf` | Module outputs |
| `scripts/build-db-migrator-zip.sh` | Builds `db_migrator.zip` (handler + psycopg2 + SQL files) |
| `.github/workflows/phase6-db-migrations.yml` | Rewritten — invokes Lambda, no psql |

## Deploy sequence after merge

1. `bash scripts/build-db-migrator-zip.sh` — produces `files/phase6/db_migrator.zip`
2. Wire `module "db_migrator"` into each env's `main.tf` with `vpc_id`, `private_subnet_ids`, `allowed_secret_arns`, `invoker_role_arns`
3. Add GitHub secrets: `DEV_DB_CREDENTIALS_SECRET_ARN`, `STAGING_DB_CREDENTIALS_SECRET_ARN` (PROD already exists)
4. `terraform apply` to deploy the Lambda in each environment
5. Re-run `phase6-db-migrations.yml` — invokes Lambda, migrations run inside VPC