### PR TITLE
fix: Phase 6 Track 1 prod deploy blockers — zip path, secret ARN, migration workflow

### DIFF
--- a/landing-zone/environments/prod/main.tf
+++ b/landing-zone/environments/prod/main.tf
@@ -159,6 +159,11 @@ module "marketplace" {
 
 # ============================================================================
 # Phase 6 / DB Migrator
+# VPC-resident Lambda that applies Aurora migrations from within the private subnet.
+# GitHub Actions runners have no direct VPC path to Aurora — this Lambda bridges that gap.
+#
+# FIX (blocker 1): zip_path corrected from ../../../ to ../../ (two levels up from prod/ to repo root)
+# FIX (blocker 2): allowed_secret_arns now references prod secret via var.prod_db_credentials_secret_arn
 # ============================================================================
 module "db_migrator" {
   source = "../../modules/db-migrator"
@@ -166,10 +171,13 @@ module "db_migrator" {
   environment        = var.environment
   vpc_id             = "vpc-003c9d5b0f9f1a02b"
   private_subnet_ids = ["subnet-0783b18ae893a8df9", "subnet-0f3dfdab04381608c"]
-  zip_path           = "${path.module}/../../../files/phase6/db_migrator.zip"
-  allowed_secret_arns = [
-    "arn:aws:secretsmanager:us-east-1:731184206915:secret:securebase/dev/rds/admin-password-sejDay"
-  ]
+
+  # Corrected path: landing-zone/environments/prod/ → ../../ → landing-zone/ → ../../ → repo root
+  zip_path = "${path.module}/../../files/phase6/db_migrator.zip"
+
+  # Prod secret ARN — set via GitHub secret PROD_DB_CREDENTIALS_SECRET_ARN
+  allowed_secret_arns = [var.prod_db_credentials_secret_arn]
+
   invoker_role_arns = [
     "arn:aws:iam::731184206915:role/GitHubActionsRole"
   ]

--- a/landing-zone/environments/prod/variables.tf
+++ b/landing-zone/environments/prod/variables.tf
@@ -170,3 +170,13 @@ variable "aws_marketplace_sns_topic_arn" {
   type        = string
   default     = ""
 }
+
+# ============================================================================
+# Phase 6 / DB Migrator — prod secret ARN
+# Set via GitHub secret PROD_DB_CREDENTIALS_SECRET_ARN passed as TF_VAR_prod_db_credentials_secret_arn
+# ============================================================================
+variable "prod_db_credentials_secret_arn" {
+  description = "Secrets Manager ARN for prod Aurora credentials — used by db_migrator Lambda IAM policy"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Problem

Three blockers identified via triage preventing Phase 6 Track 1 from deploying to prod. June 13 conversion deadline requires these fixed before June 7.

---

## What's already fixed in this PR (2 of 3)

### Fix 1 — `db_migrator` zip path was wrong (`landing-zone/environments/prod/main.tf`)

```hcl
# Before (3 levels up — points outside repo root)
zip_path = "${path.module}/../../../files/phase6/db_migrator.zip"

# After (2 levels up — correct: prod/ → landing-zone/ → repo root)
zip_path = "${path.module}/../../files/phase6/db_migrator.zip"
```

`terraform apply` would have failed with "file not found" on every run.

### Fix 2 — `db_migrator` `allowed_secret_arns` had dev secret ARN hardcoded (`landing-zone/environments/prod/main.tf`)

```hcl
# Before — hardcoded dev secret, Lambda denied in prod
allowed_secret_arns = [
  "arn:aws:secretsmanager:us-east-1:731184206915:secret:securebase/dev/rds/admin-password-sejDay"
]

# After — uses prod secret via variable
allowed_secret_arns = [var.prod_db_credentials_secret_arn]
```

Added `prod_db_credentials_secret_arn` variable to `variables.tf`. Set via:
```
TF_VAR_prod_db_credentials_secret_arn = ${{ secrets.PROD_DB_CREDENTIALS_SECRET_ARN }}
```

---

## Fix 3 — Migration workflow must invoke db_migrator Lambda, not psql directly (needs `workflows` permission)

**Copilot: please complete this fix.**

PR #848 added the `db_migrator` Lambda specifically because GitHub runners have no VPC path to Aurora — direct `psql` always times out. But `run-phase6-migrations.sh` still calls `psql` directly. The workflow needs updating.

**File to update:** `.github/workflows/phase6-db-migrations.yml`

**Change the `migrate-prod` job's "Run Phase 6 migrations" and "Validate required tables" steps** to invoke the Lambda instead of running the shell script:

```yaml
- name: Invoke db_migrator Lambda (prod)
  run: |
    echo "Invoking securebase-production-db-migrator..."
    aws lambda invoke \
      --function-name securebase-production-db-migrator \
      --payload '{"environment":"production"}' \
      --cli-binary-format raw-in-base64-out \
      --region us-east-1 \
      response.json
    cat response.json
    if cat response.json | python3 -c "import sys,json; r=json.load(sys.stdin); sys.exit(1 if r.get('errorMessage') or r.get('error') else 0)"; then
      echo "Migration completed successfully."
    else
      echo "Migration Lambda reported an error." >&2
      exit 1
    fi

- name: Verify required tables via Lambda
  run: |
    aws lambda invoke \
      --function-name securebase-production-db-migrator \
      --payload '{"environment":"production","validate_only":true}' \
      --cli-binary-format raw-in-base64-out \
      --region us-east-1 \
      validate.json
    cat validate.json
    if cat validate.json | python3 -c "import sys,json; r=json.load(sys.stdin); sys.exit(1 if r.get('errorMessage') or r.get('error') else 0)"; then
      echo "Table validation passed."
    else
      echo "Table validation failed." >&2
      exit 1
    fi
```

Apply the same Lambda-invocation pattern to `migrate-nonprod` (replace "Install PostgreSQL client tools" + "Run Phase 6 migrations" steps), using `securebase-${TARGET_ENV}-db-migrator` as the function name.

Also remove the `Install PostgreSQL client tools` step from both jobs — psql is no longer needed.

---

## GitHub secrets required before prod deploy (operator action — not a code change)

Confirm these exist in GitHub → Settings → Secrets:

| Secret | Required for |
|---|---|
| `AWS_ROLE_ARN_PROD` | prod migration job AWS credentials |
| `PROD_DB_CREDENTIALS_SECRET_ARN` | passed as `TF_VAR_prod_db_credentials_secret_arn` to terraform apply |

---

## Deploy sequence after this PR merges

1. Build Lambda zips: `bash scripts/build-db-migrator-zip.sh`
2. `terraform apply` — deploys db_migrator Lambda with correct prod secret ARN
3. Dispatch `phase6-db-migrations.yml` → dev
4. Dispatch `phase6-db-migrations.yml` → staging (`confirmed=MIGRATE`)
5. Dispatch `phase6-db-migrations.yml` → prod (`confirmed=MIGRATE`)
6. Dispatch `terraform-securebase-apply.yml` → prod (`confirmed=DEPLOY`)

**Deadline: June 7** — Matthew's conversion call is June 8. Vault must be live before then.
