### PR TITLE
fix: wire db_migrator module into dev and staging environments

### DIFF
--- a/landing-zone/environments/dev/main.tf
+++ b/landing-zone/environments/dev/main.tf
@@ -240,9 +240,6 @@ module "phase6_alerting" {
   environment = var.environment
   sns_topic_arn = module.phase5_alerting.alert_sns_arn
 
-  # audit_log_packager is deployed by the securebase root module; its name/log group
-  # follow the standard naming convention. These are hardcoded here because the
-  # phase6-audit-logging module does not currently expose them as outputs.
   packager_function_name = "securebase-${var.environment}-audit-log-packager"
   packager_log_group     = "/aws/lambda/securebase-${var.environment}-audit-log-packager"
 
@@ -305,4 +302,31 @@ module "marketplace" {
   private_subnet_ids        = var.lambda_subnets
   lambda_security_group_id  = var.marketplace_lambda_security_group_id
   tags                      = merge(var.tags, { Phase = "marketplace" })
+}
+
+# ============================================================================
+# Phase 6 / DB Migrator
+# VPC-resident Lambda that applies Aurora migrations from within the private subnet.
+# GitHub Actions runners have no direct VPC path to Aurora — this Lambda bridges that gap.
+# Secret ARN is injected via GitHub secret DEV_DB_CREDENTIALS_SECRET_ARN
+# passed as TF_VAR_dev_db_credentials_secret_arn.
+# ============================================================================
+module "db_migrator" {
+  source = "../../modules/db-migrator"
+
+  environment        = var.environment
+  vpc_id             = var.default_vpc_id
+  private_subnet_ids = var.lambda_subnets
+  zip_path           = "${path.module}/../../files/phase6/db_migrator.zip"
+
+  allowed_secret_arns = [var.dev_db_credentials_secret_arn]
+
+  invoker_role_arns = [
+    "arn:aws:iam::731184206915:role/GitHubActionsRole"
+  ]
+
+  tags = merge(var.tags, {
+    Phase = "6"
+    Track = "migrations"
+  })
 }

--- a/landing-zone/environments/dev/variables.tf
+++ b/landing-zone/environments/dev/variables.tf
@@ -352,3 +352,14 @@ variable "marketplace_lambda_security_group_id" {
   type        = string
   default     = ""
 }
+
+# ============================================================================
+# Phase 6 / DB Migrator — dev secret ARN
+# Set via GitHub secret DEV_DB_CREDENTIALS_SECRET_ARN
+# passed as TF_VAR_dev_db_credentials_secret_arn
+# ============================================================================
+variable "dev_db_credentials_secret_arn" {
+  description = "Secrets Manager ARN for dev Aurora credentials — used by db_migrator Lambda IAM policy"
+  type        = string
+  default     = ""
+}

--- a/landing-zone/environments/staging/main.tf
+++ b/landing-zone/environments/staging/main.tf
@@ -8,13 +8,40 @@ provider "aws" {
 
 # Call the root module
 module "securebase" {
-  source = "../.."
-  
-  org_name       = var.org_name
-  target_region  = var.target_region
-  environment    = var.environment
-  accounts       = var.accounts
+  source = "../.."  
+
+  org_name        = var.org_name
+  target_region   = var.target_region
+  environment     = var.environment
+  accounts        = var.accounts
   allowed_regions = var.allowed_regions
-  clients        = var.clients
-  tags           = var.tags
+  clients         = var.clients
+  tags            = var.tags
+}
+
+# ============================================================================
+# Phase 6 / DB Migrator
+# VPC-resident Lambda that applies Aurora migrations from within the private subnet.
+# GitHub Actions runners have no direct VPC path to Aurora — this Lambda bridges that gap.
+# Secret ARN is injected via GitHub secret STAGING_DB_CREDENTIALS_SECRET_ARN
+# passed as TF_VAR_staging_db_credentials_secret_arn.
+# ============================================================================
+module "db_migrator" {
+  source = "../../modules/db-migrator"
+
+  environment        = var.environment
+  vpc_id             = var.vpc_id
+  private_subnet_ids = var.private_subnet_ids
+  zip_path           = "${path.module}/../../files/phase6/db_migrator.zip"
+
+  allowed_secret_arns = [var.staging_db_credentials_secret_arn]
+
+  invoker_role_arns = [
+    "arn:aws:iam::731184206915:role/GitHubActionsRole"
+  ]
+
+  tags = merge(var.tags, {
+    Phase = "6"
+    Track = "migrations"
+  })
 }

--- a/landing-zone/environments/staging/variables.tf
+++ b/landing-zone/environments/staging/variables.tf
@@ -34,7 +34,7 @@ variable "allowed_regions" {
 variable "tags" {
   description = "Common tags for all SecureBase resources"
   type        = map(string)
-  default     = {
+  default = {
     Project   = "SecureBase"
     ManagedBy = "Terraform"
   }
@@ -43,16 +43,16 @@ variable "tags" {
 variable "clients" {
   description = "Map of customer/client configurations for multi-tenant PaaS deployments"
   type = map(object({
-    tier         = string              # Customer service tier
-    account_id   = string              # AWS account ID (if bringing your own account)
-    prefix       = string              # Resource naming prefix
-    framework    = string              # Compliance framework (soc2, hipaa, fedramp, cis)
-    vpce_id      = optional(string)    # VPC endpoint ID (required for certain tiers)
-    audit_bucket = optional(string)    # Custom audit log bucket name
-    tags         = optional(map(string)) # Client-specific tags
+    tier         = string
+    account_id   = string
+    prefix       = string
+    framework    = string
+    vpce_id      = optional(string)
+    audit_bucket = optional(string)
+    tags         = optional(map(string))
   }))
   default = {}
-  
+
   validation {
     condition = alltrue([
       for client_key, client_config in var.clients :
@@ -60,7 +60,7 @@ variable "clients" {
     ])
     error_message = "All client tiers must be one of: standard, healthcare, fintech, gov-federal"
   }
-  
+
   validation {
     condition = alltrue([
       for client_key, client_config in var.clients :
@@ -68,4 +68,27 @@ variable "clients" {
     ])
     error_message = "All client frameworks must be one of: soc2, hipaa, fedramp, cis"
   }
+}
+
+variable "vpc_id" {
+  description = "VPC ID for db_migrator Lambda"
+  type        = string
+  default     = ""
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for db_migrator Lambda"
+  type        = list(string)
+  default     = []
+}
+
+# ============================================================================
+# Phase 6 / DB Migrator — staging secret ARN
+# Set via GitHub secret STAGING_DB_CREDENTIALS_SECRET_ARN
+# passed as TF_VAR_staging_db_credentials_secret_arn
+# ============================================================================
+variable "staging_db_credentials_secret_arn" {
+  description = "Secrets Manager ARN for staging Aurora credentials — used by db_migrator Lambda IAM policy"
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
## What this is

Post-merge deploy work from PR #848. Prod was already wired at merge time. Dev and staging were missing the `module "db_migrator"` block and the corresponding secret ARN variable.

## Changes

| File | Change |
|------|--------|
| `landing-zone/environments/dev/main.tf` | Add `module "db_migrator"` wired to `var.default_vpc_id`, `var.lambda_subnets`, `var.dev_db_credentials_secret_arn` |
| `landing-zone/environments/dev/variables.tf` | Add `dev_db_credentials_secret_arn` variable |
| `landing-zone/environments/staging/main.tf` | Add `module "db_migrator"` wired to `var.vpc_id`, `var.private_subnet_ids`, `var.staging_db_credentials_secret_arn` |
| `landing-zone/environments/staging/variables.tf` | Add `staging_db_credentials_secret_arn`, `vpc_id`, `private_subnet_ids` variables |

## Before merging — add two GitHub secrets

Go to **Settings → Secrets and variables → Actions** and add:

```
DEV_DB_CREDENTIALS_SECRET_ARN
  = arn:aws:secretsmanager:us-east-1:731184206915:secret:securebase/dev/rds/admin-password-sejDay

STAGING_DB_CREDENTIALS_SECRET_ARN
  = <staging secret ARN from Secrets Manager>
```

Both will be passed as `TF_VAR_dev_db_credentials_secret_arn` / `TF_VAR_staging_db_credentials_secret_arn` by the workflow.

## After merge — run terraform apply

```bash
# Fix local Terraform binary first if still broken:
brew upgrade hashicorp/tap/terraform

# Dev
cd landing-zone/environments/dev
terraform init -backend-config=backend.hcl -reconfigure
terraform apply

# Staging
cd ../staging
terraform init -backend-config=backend.hcl -reconfigure
terraform apply
```

Then re-run `phase6-db-migrations.yml` — it will invoke the Lambda in each env and migrations will run inside the VPC.

## June 13 deadline impact

This unblocks the Day-1 evidence package delivery to Matthew Matturro / TriNetX.