### PR TITLE
fix(demo): remove Book Live Demo CTA — blank page dead end

### DIFF
--- a/phase3a-portal/src/components/DemoBanner.jsx
+++ b/phase3a-portal/src/components/DemoBanner.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AlertCircle } from 'lucide-react';
-import { trackEvent, trackCTAClick } from '../utils/analytics';
+import { trackEvent } from '../utils/analytics';
 import { isDemoMode } from '../utils/demoData';
 
 const PRICING_URL = 'https://securebase.tximhotep.com/pricing';
@@ -9,8 +9,6 @@ const DemoBanner = () => {
   // isDemoMode() covers VITE_DEMO_MODE, localStorage demo_mode, and ?demo=true.
   // Also show when VITE_USE_MOCK_API=true (mock-API dev mode), which isDemoMode() does not cover.
   if (!isDemoMode() && import.meta.env.VITE_USE_MOCK_API !== 'true') return null;
-
-  const bookDemoUrl = import.meta.env.VITE_DEMO_CTA_BOOK_DEMO_URL || 'https://securebase.tximhotep.com/contact';
 
   const handlePricingClick = () => {
     trackEvent('demo_to_pricing_cta_click', { source_page: window.location.pathname });
@@ -38,15 +36,6 @@ const DemoBanner = () => {
             className="gradient-bg text-white border-2 border-white px-5 py-2 rounded-lg font-bold text-sm hover:opacity-90 transition shadow-md"
           >
             Ready to deploy? See pricing →
-          </a>
-          <a
-            href={bookDemoUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => trackCTAClick('book_demo', 'demo_banner')}
-            className="bg-blue-500 text-white px-4 py-2 rounded-lg font-semibold text-sm hover:bg-blue-400 transition"
-          >
-            Book Live Demo
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Problem

The "Book Live Demo" button in `DemoBanner.jsx` resolves to `https://securebase.tximhotep.com/contact` (via `VITE_DEMO_CTA_BOOK_DEMO_URL` fallback). That route does not exist on the marketing site — clicking it renders a blank page with no error, no feedback, nothing.

This is the worst possible outcome for a top-of-funnel CTA. Every demo visitor who clicks it concludes the product is broken.

## Fix

Remove the button entirely. The single remaining CTA — **"Ready to deploy? See pricing →"** — routes to the live pricing page, which is the correct and only conversion path from the demo.

Also removed the now-unused `trackCTAClick` import and `VITE_DEMO_CTA_BOOK_DEMO_URL` env var reference.

## After merge

Trigger a manual deploy to `securebase-demo` (site ID `e2653a23`):
```bash
cd phase3a-portal
NETLIFY_SITE_ID=e2653a23-41aa-41bd-81a3-7195a455f1ab npx netlify deploy --prod
```

Or dispatch `deploy-phase3a-production.yml` targeting the demo site.