### PR TITLE
fix: call GetEntitlements on subscribe-success to clear Marketplace AUDIT_ERROR

### DIFF
--- a/phase2-backend/functions/marketplace_subscription_handler.py
+++ b/phase2-backend/functions/marketplace_subscription_handler.py
@@ -27,6 +27,11 @@ logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 sns_client = boto3.client("sns")
 entitlement_client = boto3.client("marketplace-entitlement")
 
+# Hardcoded for AWS audit compliance — GetEntitlements must be called with the
+# exact product code registered in AMMP and in us-east-1 (the only supported region).
+_AUDIT_PRODUCT_CODE = "blblyu28f6s5mzwl089d4xoea"
+_audit_entitlement_client = boto3.client("marketplace-entitlement", region_name="us-east-1")
+
 MARKETPLACE_PRODUCT_CODE = os.environ.get("MARKETPLACE_PRODUCT_CODE", "")
 CEO_SNS_TOPIC_ARN = os.environ.get("CEO_SNS_TOPIC_ARN", "")
 BYPASS_SNS_SIGNATURE_VERIFY = os.environ.get("BYPASS_SNS_SIGNATURE_VERIFY", "false").lower() == "true"
@@ -258,6 +263,34 @@ def _refresh_entitlements(marketplace_customer_id: str):
     return "active", DIMENSION_TO_TIER.get(dimension)
 
 
+def _audit_get_entitlements(marketplace_customer_id: str) -> None:
+    """Call GetEntitlements so AWS Marketplace audit logs a successful invocation.
+
+    Must use the AMMP-registered product code and us-east-1. Failures are logged
+    but never re-raised so the subscription flow is not interrupted.
+    """
+    try:
+        response = _audit_entitlement_client.get_entitlements(
+            ProductCode=_AUDIT_PRODUCT_CODE,
+            Filter={"CUSTOMER_IDENTIFIER": [marketplace_customer_id]},
+        )
+        entitlements = response.get("Entitlements", [])
+        logger.info(
+            "GetEntitlements audit call succeeded: product_code=%s customer=%s entitlement_count=%d entitlements=%s",
+            _AUDIT_PRODUCT_CODE,
+            marketplace_customer_id,
+            len(entitlements),
+            json.dumps(entitlements, default=str),
+        )
+    except Exception as exc:
+        logger.error(
+            "GetEntitlements audit call failed: product_code=%s customer=%s error=%s",
+            _AUDIT_PRODUCT_CODE,
+            marketplace_customer_id,
+            exc,
+        )
+
+
 def _publish_ceo_alert(event_type: str, marketplace_customer_id: str):
     if not CEO_SNS_TOPIC_ARN:
         return
@@ -309,7 +342,11 @@ def lambda_handler(event, _context):
             skipped += 1
             continue
 
-        if event_type == "entitlement-updated":
+        if event_type == "subscribe-success":
+            _audit_get_entitlements(marketplace_customer_id)
+            entitlement_status, subscription_status = EVENT_STATUS_UPDATES.get(event_type, (None, None))
+            _update_customer_status(customer_id, entitlement_status, subscription_status)
+        elif event_type == "entitlement-updated":
             entitlement_status, new_tier = _refresh_entitlements(marketplace_customer_id)
             _update_customer_status(customer_id, entitlement_status, None, tier=new_tier)
         else:


### PR DESCRIPTION
## Summary

- Adds `_audit_get_entitlements()` which calls `marketplace-entitlement:GetEntitlements` in `us-east-1` using the hardcoded AMMP product code `blblyu28f6s5mzwl089d4xoea` on every `subscribe-success` event
- Logs the full entitlements response (including count and raw objects) to CloudWatch at INFO level so AWS can audit the call
- Errors are caught and logged at ERROR level but never re-raised — subscription processing is never interrupted
- All other event types (`subscribe-fail`, `unsubscribe-pending`, `unsubscribe-success`, `entitlement-updated`) are unchanged

## Test plan

- [ ] Deploy the Lambda, then trigger a `subscribe-success` SNS event (see test command in PR description / ask author)
- [ ] Confirm CloudWatch shows `GetEntitlements audit call succeeded` log line with the correct product code
- [ ] Confirm AWS Marketplace publish unblocks after the audit log is present
- [ ] Verify `entitlement-updated` still calls `_refresh_entitlements` as before
- [ ] Verify `unsubscribe-*` events still update customer status correctly