### PR TITLE
fix(marketplace): fire audit GetEntitlements before customer lookup

### DIFF
--- a/phase2-backend/functions/marketplace_subscription_handler.py
+++ b/phase2-backend/functions/marketplace_subscription_handler.py
@@ -331,6 +331,9 @@ def lambda_handler(event, _context):
             skipped += 1
             continue
 
+        if event_type == "subscribe-success":
+            _audit_get_entitlements(marketplace_customer_id)
+
         customer_id = _lookup_customer(marketplace_customer_id)
         if not customer_id:
             logger.warning("No customer found for marketplace id %s", marketplace_customer_id)
@@ -343,7 +346,6 @@ def lambda_handler(event, _context):
             continue
 
         if event_type == "subscribe-success":
-            _audit_get_entitlements(marketplace_customer_id)
             entitlement_status, subscription_status = EVENT_STATUS_UPDATES.get(event_type, (None, None))
             _update_customer_status(customer_id, entitlement_status, subscription_status)
         elif event_type == "entitlement-updated":


### PR DESCRIPTION
## Summary

- `_audit_get_entitlements()` was positioned after the `_lookup_customer()` guard, so any `subscribe-success` event for a customer not yet in the database caused an early `skipped += 1 / continue` before the audit call was ever reached — explaining the missing GetEntitlements logs in CloudWatch.
- Moved the `_audit_get_entitlements()` call to immediately after the `marketplace_customer_id` is extracted, before any DB lookup or validation. It now fires unconditionally on every `subscribe-success` event regardless of whether the customer exists.
- The rest of the per-event logic (customer lookup, audit event upsert, status update, CEO alert) is unchanged.

## Test plan

- [ ] Deploy to staging and send a `subscribe-success` SNS event for a `customerIdentifier` that does **not** exist in the DB — confirm CloudWatch now logs `GetEntitlements audit call succeeded` and the handler still returns `{"processed": 0, "skipped": 1}`.
- [ ] Send a `subscribe-success` event for a known customer — confirm the audit log fires **and** the customer status is updated to `active`.
- [ ] Send a non-`subscribe-success` event (e.g. `unsubscribe-success`) — confirm no extra `GetEntitlements` call appears in CloudWatch.