### PR TITLE
Remove Entitlement Service VPC endpoint, fix Metering endpoint

### DIFF
--- a/landing-zone/environments/dev/main.tf
+++ b/landing-zone/environments/dev/main.tf
@@ -301,6 +301,7 @@ module "marketplace" {
   marketplace_product_code  = var.marketplace_product_code
   private_subnet_ids        = var.lambda_subnets
   lambda_security_group_id  = var.marketplace_lambda_security_group_id
+  vpc_id                    = var.default_vpc_id
   tags                      = merge(var.tags, { Phase = "marketplace" })
 }
 

--- a/landing-zone/main.tf
+++ b/landing-zone/main.tf
@@ -228,6 +228,7 @@ module "marketplace" {
   marketplace_product_code  = var.marketplace_product_code
   private_subnet_ids        = var.lambda_subnets != null ? var.lambda_subnets : aws_subnet.lambda.*.id
   lambda_security_group_id  = module.phase2_database.lambda_security_group_id
+  vpc_id                    = var.default_vpc_id != null ? var.default_vpc_id : aws_vpc.default[0].id
   tags                      = var.tags
 
   depends_on = [module.lambda_functions, module.phase2_database]

--- a/landing-zone/modules/marketplace/main.tf
+++ b/landing-zone/modules/marketplace/main.tf
@@ -372,15 +372,16 @@ resource "aws_cloudwatch_metric_alarm" "subscription_handler_errors" {
 }
 
 # ---------------------------------------------------------------------------
-# VPC endpoints — AWS Marketplace Entitlement + Metering Service APIs.
+# VPC endpoint — AWS Marketplace Metering Service API.
 #
 # All three marketplace Lambdas run inside vpc_config (private subnets, no
-# NAT/IGW route to the public internet). Without these interface endpoints,
-# any GetEntitlements call (resolve_customer, subscription_handler's
-# _cold_start_audit) or BatchMeterUsage call (metering_worker) has no route
-# out and hangs until the client-side timeout fires (see the 5s timeout
-# added to the entitlement clients as a stopgap — that timeout stays in
-# place as defense-in-depth even with these endpoints present).
+# NAT/IGW route to the public internet). Without this interface endpoint,
+# the BatchMeterUsage call (metering_worker) has no route out and hangs
+# until the client-side timeout fires (see the 5s timeout added to the
+# entitlement/metering clients as a stopgap — that timeout stays in place
+# as defense-in-depth even with this endpoint present). There is no
+# equivalent PrivateLink endpoint for the Entitlement Service — see note
+# below.
 #
 # Security group: a dedicated SG scoped to 443 ingress from the Lambda SG
 # only, rather than reusing lambda_security_group_id directly as the
@@ -391,7 +392,7 @@ resource "aws_cloudwatch_metric_alarm" "subscription_handler_errors" {
 resource "aws_security_group" "marketplace_vpc_endpoints" {
   count       = var.create_marketplace_vpc_endpoints ? 1 : 0
   name        = "securebase-${var.environment}-marketplace-vpc-endpoints"
-  description = "Allows marketplace Lambdas to reach the AWS Marketplace Entitlement and Metering Service interface endpoints over HTTPS"
+  description = "Allows marketplace Lambdas to reach the AWS Marketplace Metering Service interface endpoint over HTTPS"
   vpc_id      = var.vpc_id
 
   ingress {
@@ -413,24 +414,20 @@ resource "aws_security_group" "marketplace_vpc_endpoints" {
   tags = local.common_tags
 }
 
-resource "aws_vpc_endpoint" "marketplace_entitlement" {
-  count               = var.create_marketplace_vpc_endpoints ? 1 : 0
-  vpc_id              = var.vpc_id
-  service_name        = "com.amazonaws.${var.aws_region}.aws-marketplace-entitlement"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = var.private_subnet_ids
-  security_group_ids  = [aws_security_group.marketplace_vpc_endpoints[0].id]
-  private_dns_enabled = true
-
-  tags = merge(local.common_tags, {
-    Name = "securebase-${var.environment}-marketplace-entitlement"
-  })
-}
+# aws_vpc_endpoint.marketplace_entitlement intentionally omitted.
+# AWS does not publish a PrivateLink Interface endpoint for the Marketplace
+# Entitlement Service in us-east-1 (verified via `aws ec2
+# describe-vpc-endpoint-services` — only agreement-marketplace,
+# discovery-marketplace, and metering-marketplace exist). GetEntitlements
+# calls from these Lambdas have no PrivateLink path and continue to rely on
+# the 5s client-side timeout described above as defense-in-depth. Resolving
+# entitlement connectivity (e.g. via NAT/IGW egress) is a separate
+# architectural and cost decision, out of scope here.
 
 resource "aws_vpc_endpoint" "marketplace_metering" {
   count               = var.create_marketplace_vpc_endpoints ? 1 : 0
   vpc_id              = var.vpc_id
-  service_name        = "com.amazonaws.${var.aws_region}.aws-marketplace-metering"
+  service_name        = "com.amazonaws.${var.aws_region}.metering-marketplace"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = var.private_subnet_ids
   security_group_ids  = [aws_security_group.marketplace_vpc_endpoints[0].id]


### PR DESCRIPTION
## Summary
This PR removes the AWS Marketplace Entitlement Service VPC endpoint and corrects the service name for the Metering Service endpoint. The Entitlement Service does not have a PrivateLink interface endpoint available in AWS, so the endpoint resource was unnecessary and has been replaced with documentation explaining the limitation.

## Key Changes
- **Removed** `aws_vpc_endpoint.marketplace_entitlement` resource since AWS does not publish a PrivateLink interface endpoint for the Marketplace Entitlement Service
- **Added** explanatory comment documenting why the Entitlement endpoint is omitted and how the current 5s client-side timeout serves as a defense-in-depth measure
- **Fixed** the Metering Service endpoint's `service_name` from `aws-marketplace-metering` to `metering-marketplace` (the correct PrivateLink service name)
- **Updated** security group description to reference only the Metering Service endpoint
- **Updated** comments to reflect that only the Metering Service endpoint is now provisioned

## Implementation Details
- The Entitlement Service connectivity limitation is documented as a known constraint that relies on the existing 5s client-side timeout as a stopgap
- The architectural decision to resolve entitlement connectivity (via NAT/IGW egress) is noted as out of scope
- The Metering Service endpoint remains the only VPC endpoint provisioned for marketplace Lambda functions

https://claude.ai/code/session_01PiqTfH1jKpcCBdsKECi6vm