### PR TITLE
Simplify marketplace metering to flat-rate monthly subscriptions

### DIFF
--- a/phase2-backend/functions/marketplace_metering_worker.py
+++ b/phase2-backend/functions/marketplace_metering_worker.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime, timezone
 
 import boto3
+from botocore.config import Config
 
 if os.environ.get("DB_HOST") and not os.environ.get("RDS_HOST"):
     os.environ["RDS_HOST"] = os.environ["DB_HOST"]
@@ -17,8 +18,16 @@ from db_utils import get_connection, release_connection
 logger = logging.getLogger(__name__)
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
+# Short timeout for marketplace/SNS API calls — no VPC endpoint available for
+# SNS; must fail fast rather than hanging the full Lambda timeout.
+_MARKETPLACE_API_CONFIG = Config(
+    connect_timeout=5,
+    read_timeout=5,
+    retries={"max_attempts": 1},
+)
+
 metering_client = boto3.client("meteringmarketplace")
-sns_client = boto3.client("sns")
+sns_client = boto3.client("sns", config=_MARKETPLACE_API_CONFIG)
 
 MARKETPLACE_PRODUCT_CODE = os.environ.get("MARKETPLACE_PRODUCT_CODE", "")
 ALERTS_SNS_TOPIC_ARN = os.environ.get("ALERTS_SNS_TOPIC_ARN", "")
@@ -97,7 +106,12 @@ def _insert_metering_record(customer_id: str, marketplace_customer_id: str, dime
 def _publish_alert(subject: str, message: str):
     if not ALERTS_SNS_TOPIC_ARN:
         return
-    sns_client.publish(TopicArn=ALERTS_SNS_TOPIC_ARN, Subject=subject, Message=message)
+    try:
+        sns_client.publish(TopicArn=ALERTS_SNS_TOPIC_ARN, Subject=subject, Message=message)
+    except Exception:
+        # Alerting must never crash the worker — a missing VPC endpoint/NAT path to
+        # SNS would otherwise mask the real per-customer failure being reported.
+        logger.exception("Failed to publish alert: %s", subject)
 
 
 def _meter_customer(customer_id: str, marketplace_customer_id: str, tier: str):

--- a/phase2-backend/functions/marketplace_metering_worker.py
+++ b/phase2-backend/functions/marketplace_metering_worker.py
@@ -23,50 +23,21 @@ sns_client = boto3.client("sns")
 MARKETPLACE_PRODUCT_CODE = os.environ.get("MARKETPLACE_PRODUCT_CODE", "")
 ALERTS_SNS_TOPIC_ARN = os.environ.get("ALERTS_SNS_TOPIC_ARN", "")
 
-TIER_DIMENSIONS = {
-    "standard": ("users", 1),
-    "healthcare": ("hipaa_tenants", 1),
-    "fintech": ("fintech_tenants", 1),
-    "gov-federal": ("gov_tenants", 1),
+# Maps internal tier names to AMMP pricing dimension API names.
+# Must stay in sync with DIMENSION_TO_TIER in marketplace_subscription_handler.py
+# and the dimensions registered in the AWS Marketplace Management Portal.
+TIER_TO_DIMENSION = {
+    "standard":    "standard_monthly",
+    "healthcare":  "healthcare_monthly",
+    "fintech":     "fintech_monthly",
+    "gov-federal": "government_monthly",
 }
 
-# Dimensions that represent tenant/sub-account counts rather than user counts.
-# These query the `tenants` table grouped by customer_id.
-TENANT_DIMENSIONS = {"hipaa_tenants", "fintech_tenants", "gov_tenants"}
 
-
-def _get_metering_quantity(customer_id: str, dimension: str) -> int:
-    conn = get_connection()
-    try:
-        with conn.cursor() as cur:
-            if dimension == "users":
-                cur.execute(
-                    "SELECT COUNT(*) FROM users WHERE customer_id = %s AND status = 'active'",
-                    (customer_id,)
-                )
-            elif dimension in TENANT_DIMENSIONS:
-                cur.execute(
-                    """
-                    SELECT COALESCE(account_count, 0)
-                    FROM usage_metrics
-                    WHERE customer_id = %s
-                    ORDER BY month DESC
-                    LIMIT 1
-                    """,
-                    (customer_id,)
-                )
-            else:
-                cur.execute(
-                    "SELECT COUNT(*) FROM customers WHERE id = %s AND status = 'active'",
-                    (customer_id,)
-                )
-            row = cur.fetchone()
-            return max(1, int(row[0])) if row and row[0] else 1
-    except Exception:
-        logger.exception("Failed to get metering quantity for %s/%s", customer_id, dimension)
-        return 1
-    finally:
-        release_connection(conn)
+def _get_metering_quantity(customer_id: str) -> int:
+    # SaaS subscription dimensions are flat-rate monthly per subscriber.
+    # Quantity is always 1 — one active subscription per customer_id.
+    return 1
 
 
 def _fetch_active_marketplace_customers():
@@ -130,8 +101,8 @@ def _publish_alert(subject: str, message: str):
 
 
 def _meter_customer(customer_id: str, marketplace_customer_id: str, tier: str):
-    dimension, _ = TIER_DIMENSIONS.get(tier, ("users", 1))
-    quantity = _get_metering_quantity(customer_id, dimension)
+    dimension = TIER_TO_DIMENSION.get(tier, "standard_monthly")
+    quantity = _get_metering_quantity(customer_id)
 
     payload = {
         "CustomerIdentifier": marketplace_customer_id,
@@ -184,8 +155,8 @@ def lambda_handler(_event, _context):
                 failures += 1
         except Exception as exc:
             logger.exception("Metering failed for %s", customer_id)
-            dimension, _ = TIER_DIMENSIONS.get(tier, ("users", 1))
-            quantity = _get_metering_quantity(customer_id, dimension)
+            dimension = TIER_TO_DIMENSION.get(tier, "standard_monthly")
+            quantity = _get_metering_quantity(customer_id)
             _insert_metering_record(customer_id, marketplace_customer_id, dimension, quantity, "failed", None, str(exc))
             _publish_alert("[SecureBase Marketplace] Metering exception", json.dumps({"customer_id": customer_id, "error": str(exc)}))
             failures += 1


### PR DESCRIPTION
## Summary
Refactors the marketplace metering worker to support flat-rate monthly subscriptions instead of usage-based metering. This simplifies the metering logic and aligns with a subscription model where quantity is always 1 per customer.

## Key Changes
- **Simplified metering quantity**: Removed complex logic that queried user counts, tenant counts, and account metrics. The `_get_metering_quantity()` function now always returns 1, reflecting a flat-rate monthly subscription model per customer.
- **Updated dimension mapping**: Replaced `TIER_DIMENSIONS` with `TIER_TO_DIMENSION` that maps tier names directly to AWS Marketplace pricing dimension names (e.g., "standard" → "standard_monthly"). Removed the tuple structure that previously stored dimension names and default quantities.
- **Removed tenant-specific logic**: Eliminated `TENANT_DIMENSIONS` set and the conditional logic that queried the `usage_metrics` table for account counts.
- **Added SNS timeout configuration**: Introduced `_MARKETPLACE_API_CONFIG` with short timeouts (5s connect/read) and minimal retries for SNS calls, since there's no VPC endpoint available. This prevents the Lambda from hanging on SNS failures.
- **Improved error handling**: Wrapped `_publish_alert()` SNS call in try-except to ensure alerting failures don't crash the worker and mask actual metering issues.

## Implementation Details
- The metering quantity is now a constant (1) rather than database-dependent, eliminating database query failures as a source of metering errors.
- SNS client is configured with aggressive timeouts to fail fast rather than consuming the full Lambda timeout when SNS is unreachable.
- Alert publishing is now resilient to network/configuration issues, logging failures without propagating exceptions.
- Dimension names must stay in sync with `marketplace_subscription_handler.py` and AWS Marketplace Management Portal registrations (noted in comments).

https://claude.ai/code/session_01H8RauePCqS6Qo3Zk9ssiFJ